### PR TITLE
Ref create queues factory

### DIFF
--- a/common/middleware/queuemiddleware.go
+++ b/common/middleware/queuemiddleware.go
@@ -5,6 +5,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+type QueueMiddlewareI interface {
+	CreateConsumer(name string, durable bool) ConsumerInterface
+	CreateProducer(name string, durable bool) ProducerInterface
+	CreateExchangeProducer(nameExchange string, routingKey string, typeExchange string, durable bool) ProducerInterface
+	Close()
+}
+
 type QueueMiddleware struct {
 	channel *amqp.Channel
 	conn    *amqp.Connection

--- a/common/queuefactory/queueprotocolfactory.go
+++ b/common/queuefactory/queueprotocolfactory.go
@@ -1,0 +1,10 @@
+package queuefactory
+
+import (
+	"github.com/brunograssano/Distribuidos-TP1/common/protocol/queues"
+)
+
+type QueueProtocolFactory interface {
+	CreateProducer(string) queues.ProducerProtocolInterface
+	CreateConsumer(string) queues.ConsumerProtocolInterface
+}

--- a/common/queuefactory/simplefactory.go
+++ b/common/queuefactory/simplefactory.go
@@ -1,0 +1,24 @@
+package queuefactory
+
+import (
+	"github.com/brunograssano/Distribuidos-TP1/common/middleware"
+	"github.com/brunograssano/Distribuidos-TP1/common/protocol/queues"
+)
+
+type SimpleQueueFactory struct {
+	qMiddleware middleware.QueueMiddlewareI
+}
+
+func NewSimpleQueueFactory(qMiddleware middleware.QueueMiddlewareI) QueueProtocolFactory {
+	return &SimpleQueueFactory{qMiddleware: qMiddleware}
+}
+
+func (s SimpleQueueFactory) CreateProducer(queueName string) queues.ProducerProtocolInterface {
+	producer := s.qMiddleware.CreateProducer(queueName, true)
+	return queues.NewProducerQueueProtocolHandler(producer)
+}
+
+func (s SimpleQueueFactory) CreateConsumer(queueName string) queues.ConsumerProtocolInterface {
+	consumer := s.qMiddleware.CreateConsumer(queueName, true)
+	return queues.NewConsumerQueueProtocolHandler(consumer)
+}

--- a/common/queuefactory/uniqueexchangefactory.go
+++ b/common/queuefactory/uniqueexchangefactory.go
@@ -1,0 +1,31 @@
+package queuefactory
+
+import (
+	"github.com/brunograssano/Distribuidos-TP1/common/middleware"
+	"github.com/brunograssano/Distribuidos-TP1/common/protocol/queues"
+	log "github.com/sirupsen/logrus"
+)
+
+type UniqueExchangeQueueFactory struct {
+	qMiddleware  middleware.QueueMiddlewareI
+	exchangeName string
+	routingKey   string
+}
+
+func NewUniqueExchangeQueueFactory(qMiddleware middleware.QueueMiddlewareI, exchangeName string, routingKey string) QueueProtocolFactory {
+	return &UniqueExchangeQueueFactory{qMiddleware: qMiddleware, exchangeName: exchangeName, routingKey: routingKey}
+}
+
+func (s UniqueExchangeQueueFactory) CreateProducer(queueName string) queues.ProducerProtocolInterface {
+	producer := s.qMiddleware.CreateProducer(queueName, true)
+	return queues.NewProducerQueueProtocolHandler(producer)
+}
+
+func (s UniqueExchangeQueueFactory) CreateConsumer(queueName string) queues.ConsumerProtocolInterface {
+	consumer := s.qMiddleware.CreateConsumer(queueName, true)
+	err := consumer.BindTo(s.exchangeName, s.routingKey, "fanout")
+	if err != nil {
+		log.Fatalf("UniqueExchangeQueueFactory | Error trying to bind the consumer's queue to the exchange | %v", err)
+	}
+	return queues.NewConsumerQueueProtocolHandler(consumer)
+}

--- a/data_processor/main.go
+++ b/data_processor/main.go
@@ -4,6 +4,7 @@ import (
 	"data_processor/processor"
 	"github.com/brunograssano/Distribuidos-TP1/common/heartbeat"
 	"github.com/brunograssano/Distribuidos-TP1/common/middleware"
+	"github.com/brunograssano/Distribuidos-TP1/common/queuefactory"
 	"github.com/brunograssano/Distribuidos-TP1/common/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -22,8 +23,9 @@ func main() {
 	}
 
 	qMiddleware := middleware.NewQueueMiddleware(processorConfig.RabbitAddress)
+	qFactory := queuefactory.NewSimpleQueueFactory(qMiddleware)
 	for i := 0; i < processorConfig.GoroutinesCount; i++ {
-		r := processor.NewDataProcessor(i, qMiddleware, processorConfig)
+		r := processor.NewDataProcessor(i, qFactory, processorConfig)
 		go r.ProcessData()
 	}
 	endSignalHB := make(chan bool, 1)

--- a/data_processor/processor/dataprocessor.go
+++ b/data_processor/processor/dataprocessor.go
@@ -3,8 +3,8 @@ package processor
 import (
 	"errors"
 	dataStructures "github.com/brunograssano/Distribuidos-TP1/common/data_structures"
-	"github.com/brunograssano/Distribuidos-TP1/common/middleware"
 	queueProtocol "github.com/brunograssano/Distribuidos-TP1/common/protocol/queues"
+	"github.com/brunograssano/Distribuidos-TP1/common/queuefactory"
 	"github.com/brunograssano/Distribuidos-TP1/common/serializer"
 	"github.com/brunograssano/Distribuidos-TP1/common/utils"
 	log "github.com/sirupsen/logrus"
@@ -26,14 +26,14 @@ type DataProcessor struct {
 }
 
 // NewDataProcessor Creates a new DataProcessor structure
-func NewDataProcessor(id int, qMiddleware *middleware.QueueMiddleware, c *Config) *DataProcessor {
-	consumer := queueProtocol.NewConsumerQueueProtocolHandler(qMiddleware.CreateConsumer(c.InputQueueName, true))
+func NewDataProcessor(id int, qFactory queuefactory.QueueProtocolFactory, c *Config) *DataProcessor {
+	consumer := qFactory.CreateConsumer(c.InputQueueName)
 	var producersEx123 []queueProtocol.ProducerProtocolInterface
 	for _, queueName := range c.OutputQueueNameEx123 {
-		producersEx123 = append(producersEx123, queueProtocol.NewProducerQueueProtocolHandler(qMiddleware.CreateProducer(queueName, true)))
+		producersEx123 = append(producersEx123, qFactory.CreateProducer(queueName))
 	}
-	producersEx4 := queueProtocol.NewProducerQueueProtocolHandler(qMiddleware.CreateProducer(c.OutputQueueNameEx4, true))
-	inputQProd := queueProtocol.NewProducerQueueProtocolHandler(qMiddleware.CreateProducer(c.InputQueueName, true))
+	producersEx4 := qFactory.CreateProducer(c.OutputQueueNameEx4)
+	inputQProd := qFactory.CreateProducer(c.InputQueueName)
 	return &DataProcessor{
 		processorId:    id,
 		c:              c,

--- a/dim_reducer/main.go
+++ b/dim_reducer/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"dim_reducer/reducer"
 	"github.com/brunograssano/Distribuidos-TP1/common/middleware"
+	"github.com/brunograssano/Distribuidos-TP1/common/queuefactory"
 	"github.com/brunograssano/Distribuidos-TP1/common/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -21,8 +22,9 @@ func main() {
 	}
 
 	qMiddleware := middleware.NewQueueMiddleware(reducerConfig.RabbitAddress)
+	queueFactory := queuefactory.NewSimpleQueueFactory(qMiddleware)
 	for i := 0; i < reducerConfig.GoroutinesCount; i++ {
-		r := reducer.NewReducer(i, qMiddleware, reducerConfig)
+		r := reducer.NewReducer(i, queueFactory, reducerConfig)
 		go r.ReduceDims()
 	}
 	<-sigs

--- a/dim_reducer/reducer/reducer.go
+++ b/dim_reducer/reducer/reducer.go
@@ -2,8 +2,8 @@ package reducer
 
 import (
 	dataStructures "github.com/brunograssano/Distribuidos-TP1/common/data_structures"
-	"github.com/brunograssano/Distribuidos-TP1/common/middleware"
 	queueProtocol "github.com/brunograssano/Distribuidos-TP1/common/protocol/queues"
+	"github.com/brunograssano/Distribuidos-TP1/common/queuefactory"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -17,10 +17,10 @@ type Reducer struct {
 }
 
 // NewReducer Creates a new reducer
-func NewReducer(reducerId int, qMiddleware *middleware.QueueMiddleware, c *Config) *Reducer {
-	consumer := queueProtocol.NewConsumerQueueProtocolHandler(qMiddleware.CreateConsumer(c.InputQueueName, true))
-	producer := queueProtocol.NewProducerQueueProtocolHandler(qMiddleware.CreateProducer(c.OutputQueueName, true))
-	prodToCons := queueProtocol.NewProducerQueueProtocolHandler(qMiddleware.CreateProducer(c.InputQueueName, true))
+func NewReducer(reducerId int, queueFactory queuefactory.QueueProtocolFactory, c *Config) *Reducer {
+	consumer := queueFactory.CreateConsumer(c.InputQueueName)
+	producer := queueFactory.CreateProducer(c.OutputQueueName)
+	prodToCons := queueFactory.CreateProducer(c.InputQueueName)
 	return &Reducer{
 		reducerId:  reducerId,
 		c:          c,

--- a/dispatcher_ex4/dispatcher_ex4.go
+++ b/dispatcher_ex4/dispatcher_ex4.go
@@ -5,6 +5,7 @@ import (
 	"github.com/brunograssano/Distribuidos-TP1/common/dispatcher"
 	"github.com/brunograssano/Distribuidos-TP1/common/middleware"
 	queueProtocol "github.com/brunograssano/Distribuidos-TP1/common/protocol/queues"
+	"github.com/brunograssano/Distribuidos-TP1/common/queuefactory"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -16,11 +17,12 @@ type DispatcherEx4 struct {
 
 func NewDispatcherEx4(dispatcherConfig *DispatcherEx4Config) *DispatcherEx4 {
 	qMiddleware := middleware.NewQueueMiddleware(dispatcherConfig.RabbitAddress)
+	simpleFactory := queuefactory.NewSimpleQueueFactory(qMiddleware)
 	var dispatchers []*dispatcher.JourneyDispatcher
 	log.Infof("DispatcherEx4 | Creating %v dispatchers...", dispatcherConfig.DispatchersCount)
 	for idx := uint(0); idx < dispatcherConfig.DispatchersCount; idx++ {
-		inputQueue := queueProtocol.NewConsumerQueueProtocolHandler(qMiddleware.CreateConsumer(dispatcherConfig.InputQueueName, true))
-		prodToInput := queueProtocol.NewProducerQueueProtocolHandler(qMiddleware.CreateProducer(dispatcherConfig.InputQueueName, true))
+		inputQueue := simpleFactory.CreateConsumer(dispatcherConfig.InputQueueName)
+		prodToInput := simpleFactory.CreateProducer(dispatcherConfig.InputQueueName)
 		var outputQueues []queueProtocol.ProducerProtocolInterface
 		for i := uint(0); i < dispatcherConfig.SaversCount; i++ {
 			outputQueue := queueProtocol.NewProducerQueueProtocolHandler(

--- a/distance_completer/controllers/airports_saver.go
+++ b/distance_completer/controllers/airports_saver.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	dataStructures "github.com/brunograssano/Distribuidos-TP1/common/data_structures"
 	"github.com/brunograssano/Distribuidos-TP1/common/filemanager"
-	"github.com/brunograssano/Distribuidos-TP1/common/middleware"
 	"github.com/brunograssano/Distribuidos-TP1/common/protocol/queues"
+	"github.com/brunograssano/Distribuidos-TP1/common/queuefactory"
 	"github.com/brunograssano/Distribuidos-TP1/common/utils"
 	log "github.com/sirupsen/logrus"
 	"strings"
@@ -20,16 +20,12 @@ type AirportSaver struct {
 
 func NewAirportSaver(
 	conf *config.CompleterConfig,
-	qMiddleware *middleware.QueueMiddleware,
+	qFactory queuefactory.QueueProtocolFactory,
 ) *AirportSaver {
-	consumer := qMiddleware.CreateConsumer(fmt.Sprintf("%v-%v", conf.InputQueueAirportsName, conf.ID), true)
-	err := consumer.BindTo(conf.ExchangeNameAirports, conf.RoutingKeyExchangeAirports, "fanout")
-	if err != nil {
-		log.Fatalf("AirportsSaver | Error trying to bind the consumer's queue to the exchange | %v", err)
-	}
+	consumer := qFactory.CreateConsumer(fmt.Sprintf("%v-%v", conf.InputQueueAirportsName, conf.ID))
 	return &AirportSaver{
 		c:          conf,
-		consumer:   queues.NewConsumerQueueProtocolHandler(consumer),
+		consumer:   consumer,
 		fileSavers: make(map[string]*filemanager.FileWriter),
 	}
 }

--- a/distance_completer/controllers/distance_completer.go
+++ b/distance_completer/controllers/distance_completer.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	dataStructures "github.com/brunograssano/Distribuidos-TP1/common/data_structures"
 	"github.com/brunograssano/Distribuidos-TP1/common/filemanager"
-	"github.com/brunograssano/Distribuidos-TP1/common/middleware"
 	queueProtocol "github.com/brunograssano/Distribuidos-TP1/common/protocol/queues"
+	"github.com/brunograssano/Distribuidos-TP1/common/queuefactory"
 	"github.com/brunograssano/Distribuidos-TP1/common/serializer"
 	"github.com/brunograssano/Distribuidos-TP1/common/utils"
 	log "github.com/sirupsen/logrus"
@@ -25,12 +25,12 @@ type DistanceCompleter struct {
 
 func NewDistanceCompleter(
 	id int,
-	qMiddleware *middleware.QueueMiddleware,
+	qFactory queuefactory.QueueProtocolFactory,
 	c *config.CompleterConfig,
 ) *DistanceCompleter {
-	consumer := queueProtocol.NewConsumerQueueProtocolHandler(qMiddleware.CreateConsumer(c.InputQueueFlightsName, true))
-	producer := queueProtocol.NewProducerQueueProtocolHandler(qMiddleware.CreateProducer(c.OutputQueueName, true))
-	producerForCons := queueProtocol.NewProducerQueueProtocolHandler(qMiddleware.CreateProducer(c.InputQueueFlightsName, true))
+	consumer := qFactory.CreateConsumer(c.InputQueueFlightsName)
+	producer := qFactory.CreateProducer(c.OutputQueueName)
+	producerForCons := qFactory.CreateProducer(c.InputQueueFlightsName)
 
 	return &DistanceCompleter{
 		completerId:  id,

--- a/distance_completer/main.go
+++ b/distance_completer/main.go
@@ -4,6 +4,7 @@ import (
 	"distance_completer/config"
 	"distance_completer/controllers"
 	"github.com/brunograssano/Distribuidos-TP1/common/middleware"
+	"github.com/brunograssano/Distribuidos-TP1/common/queuefactory"
 	"github.com/brunograssano/Distribuidos-TP1/common/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -22,11 +23,12 @@ func main() {
 	}
 
 	qMiddleware := middleware.NewQueueMiddleware(completerConfig.RabbitAddress)
-
+	simpleFactory := queuefactory.NewSimpleQueueFactory(qMiddleware)
+	exchangeFactory := queuefactory.NewUniqueExchangeQueueFactory(qMiddleware, completerConfig.ExchangeNameAirports, completerConfig.RoutingKeyExchangeAirports)
 	for i := 0; i < completerConfig.GoroutinesCount; i++ {
 		distCompleter := controllers.NewDistanceCompleter(
 			i,
-			qMiddleware,
+			simpleFactory,
 			completerConfig,
 		)
 		go distCompleter.CompleteDistances()
@@ -34,7 +36,7 @@ func main() {
 
 	airportsSaver := controllers.NewAirportSaver(
 		completerConfig,
-		qMiddleware,
+		exchangeFactory,
 	)
 	go airportsSaver.SaveAirports()
 

--- a/ex4_sink/main.go
+++ b/ex4_sink/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/brunograssano/Distribuidos-TP1/common/middleware"
-	queueProtocol "github.com/brunograssano/Distribuidos-TP1/common/protocol/queues"
+	"github.com/brunograssano/Distribuidos-TP1/common/queuefactory"
 	"github.com/brunograssano/Distribuidos-TP1/common/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -18,8 +18,9 @@ func main() {
 		log.Fatalf("Main - Ex4 Sink | Error initializing Config | %s", err)
 	}
 	qMiddleware := middleware.NewQueueMiddleware(config.RabbitAddress)
-	inputQueue := queueProtocol.NewConsumerQueueProtocolHandler(qMiddleware.CreateConsumer(config.InputQueueName, true))
-	toSaver4 := queueProtocol.NewProducerQueueProtocolHandler(qMiddleware.CreateProducer(config.OutputQueueName, true))
+	qFactory := queuefactory.NewSimpleQueueFactory(qMiddleware)
+	inputQueue := qFactory.CreateConsumer(config.InputQueueName)
+	toSaver4 := qFactory.CreateProducer(config.OutputQueueName)
 
 	sink := NewJourneySink(inputQueue, toSaver4, config.SaversCount)
 	go sink.HandleJourneys()

--- a/filters/filter_distancias/filter_distancias.go
+++ b/filters/filter_distancias/filter_distancias.go
@@ -4,8 +4,8 @@ import (
 	"filters_config"
 	dataStructures "github.com/brunograssano/Distribuidos-TP1/common/data_structures"
 	"github.com/brunograssano/Distribuidos-TP1/common/filters"
-	"github.com/brunograssano/Distribuidos-TP1/common/middleware"
 	queueProtocol "github.com/brunograssano/Distribuidos-TP1/common/protocol/queues"
+	"github.com/brunograssano/Distribuidos-TP1/common/queuefactory"
 	"github.com/brunograssano/Distribuidos-TP1/common/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -19,12 +19,12 @@ type FilterDistances struct {
 	filter     *filters.Filter
 }
 
-func NewFilterDistances(filterId int, qMiddleware *middleware.QueueMiddleware, conf *filters_config.FilterConfig) *FilterDistances {
-	inputQueue := queueProtocol.NewConsumerQueueProtocolHandler(qMiddleware.CreateConsumer(conf.InputQueueName, true))
-	prodToCons := queueProtocol.NewProducerQueueProtocolHandler(qMiddleware.CreateProducer(conf.InputQueueName, true))
+func NewFilterDistances(filterId int, qFactory queuefactory.QueueProtocolFactory, conf *filters_config.FilterConfig) *FilterDistances {
+	inputQueue := qFactory.CreateConsumer(conf.InputQueueName)
+	prodToCons := qFactory.CreateProducer(conf.InputQueueName)
 	outputQueues := make([]queueProtocol.ProducerProtocolInterface, len(conf.OutputQueueNames))
 	for i := 0; i < len(conf.OutputQueueNames); i++ {
-		outputQueues[i] = queueProtocol.NewProducerQueueProtocolHandler(qMiddleware.CreateProducer(conf.OutputQueueNames[i], true))
+		outputQueues[i] = qFactory.CreateProducer(conf.OutputQueueNames[i])
 	}
 
 	filter := filters.NewFilter()

--- a/filters/filter_distancias/main.go
+++ b/filters/filter_distancias/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"filters_config"
 	middleware "github.com/brunograssano/Distribuidos-TP1/common/middleware"
+	"github.com/brunograssano/Distribuidos-TP1/common/queuefactory"
 	"github.com/brunograssano/Distribuidos-TP1/common/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -19,8 +20,9 @@ func main() {
 	}
 
 	qMiddleware := middleware.NewQueueMiddleware(filterDistanciaConfig.RabbitAddress)
+	qFactory := queuefactory.NewSimpleQueueFactory(qMiddleware)
 	for i := 0; i < filterDistanciaConfig.GoroutinesCount; i++ {
-		fd := NewFilterDistances(i, qMiddleware, filterDistanciaConfig)
+		fd := NewFilterDistances(i, qFactory, filterDistanciaConfig)
 		log.Infof("Main - Filter Distances | Spawning GoRoutine - Filter #%v", i)
 		go fd.FilterDistances()
 	}

--- a/filters/filter_escalas/filter_escalas.go
+++ b/filters/filter_escalas/filter_escalas.go
@@ -4,8 +4,8 @@ import (
 	"filters_config"
 	dataStructures "github.com/brunograssano/Distribuidos-TP1/common/data_structures"
 	"github.com/brunograssano/Distribuidos-TP1/common/filters"
-	"github.com/brunograssano/Distribuidos-TP1/common/middleware"
 	queueProtocol "github.com/brunograssano/Distribuidos-TP1/common/protocol/queues"
+	"github.com/brunograssano/Distribuidos-TP1/common/queuefactory"
 	"github.com/brunograssano/Distribuidos-TP1/common/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -21,12 +21,12 @@ type FilterStopovers struct {
 
 const MinStopovers = 3
 
-func NewFilterStopovers(filterId int, qMiddleware *middleware.QueueMiddleware, conf *filters_config.FilterConfig) *FilterStopovers {
-	inputQueue := queueProtocol.NewConsumerQueueProtocolHandler(qMiddleware.CreateConsumer(conf.InputQueueName, true))
-	prodToCons := queueProtocol.NewProducerQueueProtocolHandler(qMiddleware.CreateProducer(conf.InputQueueName, true))
+func NewFilterStopovers(filterId int, qFactory queuefactory.QueueProtocolFactory, conf *filters_config.FilterConfig) *FilterStopovers {
+	inputQueue := qFactory.CreateConsumer(conf.InputQueueName)
+	prodToCons := qFactory.CreateProducer(conf.InputQueueName)
 	outputQueues := make([]queueProtocol.ProducerProtocolInterface, len(conf.OutputQueueNames))
 	for i := 0; i < len(conf.OutputQueueNames); i++ {
-		outputQueues[i] = queueProtocol.NewProducerQueueProtocolHandler(qMiddleware.CreateProducer(conf.OutputQueueNames[i], true))
+		outputQueues[i] = qFactory.CreateProducer(conf.OutputQueueNames[i])
 	}
 
 	filter := filters.NewFilter()

--- a/filters/filter_escalas/main.go
+++ b/filters/filter_escalas/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"filters_config"
 	middleware "github.com/brunograssano/Distribuidos-TP1/common/middleware"
+	"github.com/brunograssano/Distribuidos-TP1/common/queuefactory"
 	"github.com/brunograssano/Distribuidos-TP1/common/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -19,8 +20,9 @@ func main() {
 	}
 
 	qMiddleware := middleware.NewQueueMiddleware(filterEscalasConfig.RabbitAddress)
+	qFactory := queuefactory.NewSimpleQueueFactory(qMiddleware)
 	for i := 0; i < filterEscalasConfig.GoroutinesCount; i++ {
-		fe := NewFilterStopovers(i, qMiddleware, filterEscalasConfig)
+		fe := NewFilterStopovers(i, qFactory, filterEscalasConfig)
 		log.Infof("Main - Filter Stopovers | Spawning GoRoutine - Filter #%v", i)
 		go fe.FilterStopovers()
 	}

--- a/simple_saver/main.go
+++ b/simple_saver/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/brunograssano/Distribuidos-TP1/common/getters"
 	"github.com/brunograssano/Distribuidos-TP1/common/middleware"
+	"github.com/brunograssano/Distribuidos-TP1/common/queuefactory"
 	"github.com/brunograssano/Distribuidos-TP1/common/utils"
 	"log"
 	"simple_saver/saver"
@@ -22,7 +23,7 @@ func main() {
 	}
 
 	qMiddleware := middleware.NewQueueMiddleware(saverConfig.RabbitAddress)
-	simpleSaver := saver.NewSimpleSaver(qMiddleware, saverConfig)
+	simpleSaver := saver.NewSimpleSaver(queuefactory.NewSimpleQueueFactory(qMiddleware), saverConfig)
 	go simpleSaver.SaveData()
 
 	getterConf := getters.NewGetterConfig(saverConfig.ID, []string{saverConfig.OutputFileName}, saverConfig.GetterAddress, saverConfig.GetterBatchLines)

--- a/simple_saver/saver/saver.go
+++ b/simple_saver/saver/saver.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	dataStructures "github.com/brunograssano/Distribuidos-TP1/common/data_structures"
 	"github.com/brunograssano/Distribuidos-TP1/common/filemanager"
-	"github.com/brunograssano/Distribuidos-TP1/common/middleware"
 	queueProtocol "github.com/brunograssano/Distribuidos-TP1/common/protocol/queues"
+	"github.com/brunograssano/Distribuidos-TP1/common/queuefactory"
 	"github.com/brunograssano/Distribuidos-TP1/common/serializer"
 	"github.com/brunograssano/Distribuidos-TP1/common/utils"
 	log "github.com/sirupsen/logrus"
@@ -18,8 +18,8 @@ type SimpleSaver struct {
 }
 
 // NewSimpleSaver Creates a new saver for the results
-func NewSimpleSaver(qMiddleware *middleware.QueueMiddleware, c *Config) *SimpleSaver {
-	consumer := queueProtocol.NewConsumerQueueProtocolHandler(qMiddleware.CreateConsumer(c.InputQueueName, true))
+func NewSimpleSaver(qFactory queuefactory.QueueProtocolFactory, c *Config) *SimpleSaver {
+	consumer := qFactory.CreateConsumer(c.InputQueueName)
 	return &SimpleSaver{c: c, consumer: consumer}
 }
 


### PR DESCRIPTION
_Para lo que es el diseño del middleware me pareció muy bueno lo que hicieron. Sin embargo encuentro lugares como por ejemplo
filter_distances.go donde ustedes arman las output queues a partir de la variable de entorno. Aca estaria bueno tener una abstracción intermedia de Middleware que se encargue
de la construcción de estas cosas y se especifica a los procesos. Ustedes buscan tener un proceso central que consume el middleware bajo logica de negocio abstrayendose de hacia
donde va esa comunicación, eso incluye el armado de queues_